### PR TITLE
Log stack if given.

### DIFF
--- a/lib/BaseLogger.js
+++ b/lib/BaseLogger.js
@@ -56,6 +56,12 @@ class BaseLogger {
   }
 
   _writeLog(level, message) {
+    // We may have sent an Error;
+    // if we have, the stack is most useful.
+    if (message && message.stack) {
+      return this._writeLog(level, message.stack);
+    }
+
     const logData = {
       timestamp: moment.utc(),
       source: this.source,

--- a/lib/Logger.spec.js
+++ b/lib/Logger.spec.js
@@ -70,6 +70,25 @@ describe("Logger", () => {
     });
   });
 
+  describe("error stacks", () => {
+    const log = logFactory({
+      source: "ThisTest",
+      level: "INFO",
+      transport
+    });
+
+    it("logs stack if given", () => {
+      const err = new Error("message");
+      log.error(err);
+      transport.spies.error.should.be.calledWith(`(ThisTest) [ERROR] ${err.stack}`);
+    });
+
+    it("does not fail if no stack given", () => {
+      log.error("message");
+      transport.spies.error.should.be.calledWith("(ThisTest) [ERROR] message");
+    });
+  });
+
   describe("log levels", () => {
     context("Level = INFO", () => {
       const log = logFactory({


### PR DESCRIPTION
If a log message has a stack property, we log the stack rather than
the message.

This allows us to `log.error(new Error("foo"))` and get the full
stack trace. (I've tested and the message comes with the stack trace.)