### PR TITLE
logging runs in a try catch to stop disruptions to control flow

### DIFF
--- a/lib/BaseLogger.js
+++ b/lib/BaseLogger.js
@@ -1,11 +1,13 @@
 "use strict";
 const events = require("./events");
 const logDataGenerator = require('./logDataGenerator');
+const LOGGERSOURCE = 'baseLogger';
 
 class BaseLogger {
 
   constructor(source) {
     this.source = source;
+    this.logDataGenerator = logDataGenerator;
   }
 
   trace(message) {
@@ -57,7 +59,17 @@ class BaseLogger {
   }
 
   _writeLog(level, message) {
-    const logData = logDataGenerator.generateLogData(level, message, this.source);
+    try {
+      this._generateLog(level, message, this.source);
+    } catch (err) {
+      // if something goes wrong try to log the error
+      try {
+        this._generateLog('ERROR', err, LOGGERSOURCE);
+      } catch (err) { /* Do nothing. We tried */ }
+    }
+  }
+  _generateLog(level, message, source) {
+    const logData = this.logDataGenerator.generateLogData(level, message, source);
     this._log(logData);
     events.emit(level, logData);
   }

--- a/lib/BaseLogger.spec.js
+++ b/lib/BaseLogger.spec.js
@@ -1,0 +1,66 @@
+"use strict";
+const BaseLogger = require("./BaseLogger");
+const should = require("should");
+const _ = require('lodash');
+const sinon = require('sinon');
+require("should-sinon");
+
+
+describe('BaseLogger', () => {
+
+  let baseLogger;
+
+  beforeEach( () => {
+    baseLogger = new BaseLogger('Source');
+    baseLogger._log = _.identity;
+  });
+
+  it('should trace', () => {
+    should( () => baseLogger.trace('message') ).not.throw();
+  });
+
+  it('should debug', () => {
+    should( () => baseLogger.debug('message') ).not.throw();
+  });
+
+  it('should info', () => {
+    should( () => baseLogger.info('message') ).not.throw();
+  });
+
+  it('should warn', () => {
+    should( () => baseLogger.warn('message') ).not.throw();
+  });
+
+  it('should error', () => {
+    should( () => baseLogger.error('message') ).not.throw();
+  });
+
+  it('should critical', () => {
+    should( () => baseLogger.critical('message') ).not.throw();
+  });
+
+  it('should throw an internal error if log errors', () => {
+    baseLogger._log = sinon.spy();
+    const spy = sinon.spy();
+    baseLogger.logDataGenerator = {
+      generateLogData: (level, message, source) => { if (source === 'Source') { spy(); throw 'error'; } }
+    };
+    baseLogger._writeLog('ERROR', 'message');
+    spy.should.be.called();
+    baseLogger._log.should.be.called();
+  });
+
+  it('should not error if logging totally fails', () => {
+    baseLogger._log = sinon.spy();
+    baseLogger.logDataGenerator = {
+      generateLogData: (level, message, source) => { throw 'error'; }
+    };
+    should( () => baseLogger._writeLog('ERROR', 'message') ).not.throw();
+  });
+
+  it('should write log', () => {
+    should( () => baseLogger._writeLog('ERROR', 'message') ).not.throw();
+  });
+
+
+});

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "eslint": "^3.3.1",
     "eslint-config-trussle": "^2.0.0",
-    "mocha": "^3.0.2",
+    "mocha": "^3.1.2",
     "should": "^11.1.0",
     "should-sinon": "0.0.5",
     "sinon": "^1.17.6"


### PR DESCRIPTION
Recently had a problem where an error was occurring on production builds but was not occurring locally, turned out this was due to the log level being different on the different environments. The initial problem was the logger trying to stringify an object that could not be stringified

If an error occurs in logging the logger will:

* Try to log that itself has thrown an error
* if that also fails, fail silently

This stops the logger from terminating the function that called it
