### PR TITLE
Added utc timestamp to default log tempalte

### DIFF
--- a/lib/Logger.spec.js
+++ b/lib/Logger.spec.js
@@ -1,10 +1,16 @@
 "use strict";
+require("should-sinon");
+
+const should = require("should");
+const sinon = require("sinon");
+const proxyquire = require("proxyquire");
+
+const SinonTransport = require("./transports/SinonTransport");
+
 const logFactory = require("./logFactory");
 const events = require("./events");
-const should = require("should");
-const SinonTransport = require("./transports/SinonTransport");
-const sinon = require("sinon");
-require("should-sinon");
+
+const template = (logData) => `(${logData.source}) [${logData.level}] ${logData.message}`;
 
 describe("Logger", () => {
   const transport = new SinonTransport();
@@ -30,121 +36,170 @@ describe("Logger", () => {
     });
   });
 
-  describe("log functions", () => {
-    context("Level = INFO", () => {
-      const log = logFactory({
-        source: "ThisTest",
+  describe('log template', () => {
+
+    const source = 'source';
+    const message = 'message';
+
+    it('When not given a template, should use the default for log messages', () => {
+      // Arrange
+      const utcTimestamp = 'timestamp';
+      const stubs = {
+        'moment': {
+          utc: () => utcTimestamp,
+          '@global': true
+        }
+      };
+
+      const factory = proxyquire('./logFactory', stubs);
+      const sut = factory({
+        source,
         level: "INFO",
         transport
       });
 
+      // Act
+      sut.error("message");
+
+      // Assert
+      transport.spies.error.should.be.calledWith(`${utcTimestamp}: (${source}) [ERROR] ${message}`);
+    });
+
+    it('When given a template, should use it rather than the default', () => {
+      // Arrange
+      const sut = logFactory({
+        source,
+        template,
+        level: "INFO",
+        transport
+      });
+
+      // Act
+      sut.error("message");
+
+      // Assert
+      transport.spies.error.should.be.calledWith(`(${source}) [ERROR] ${message}`);
+    });
+  });
+
+  describe("log functions", () => {
+    context("Level = INFO", () => {
+      const sut = logFactory({
+        source: "ThisTest",
+        level: "INFO",
+        template,
+        transport
+      });
+
       it("logs on critical", () => {
-        log.critical("message");
+        sut.critical("message");
         transport.spies.critical.should.be.calledWith("(ThisTest) [CRITICAL] message");
       });
 
       it("logs on error", () => {
-        log.error("message");
+        sut.error("message");
         transport.spies.error.should.be.calledWith("(ThisTest) [ERROR] message");
       });
 
       it("logs on warn", () => {
-        log.warn("message");
+        sut.warn("message");
         transport.spies.warn.should.be.calledWith("(ThisTest) [WARN] message");
       });
 
       it("logs on info", () => {
-        log.info("message");
+        sut.info("message");
         transport.spies.info.should.be.calledWith("(ThisTest) [INFO] message");
       });
 
       it("doesn\'t log on debug", () => {
-        log.debug("message");
+        sut.debug("message");
         transport.spies.debug.should.not.be.called();
       });
 
       it("doesn\'t log on trace", () => {
-        log.trace("message");
+        sut.trace("message");
         transport.spies.trace.should.not.be.called();
       });
     });
   });
 
   describe("error stacks", () => {
-    const log = logFactory({
+    const sut = logFactory({
       source: "ThisTest",
       level: "INFO",
+      template,
       transport
     });
 
     it("logs stack if given", () => {
       const err = new Error("message");
-      log.error(err);
+      sut.error(err);
       transport.spies.error.should.not.be.calledWith("(ThisTest) [ERROR] message");
     });
 
     it("does not fail if no stack given", () => {
-      log.error("message");
+      sut.error("message");
       transport.spies.error.should.be.calledWith("(ThisTest) [ERROR] message");
     });
   });
 
   describe("error keys", () => {
-    const log = logFactory({
+    const sut = logFactory({
       source: "ThisTest",
       level: "INFO",
+      template,
       transport
     });
 
     it("logs key if given", () => {
       const keyMessage = new Error("message");
       keyMessage.key = 'KEY';
-      log.error(keyMessage);
+      sut.error(keyMessage);
       transport.spies.error.should.not.be.calledWith("(ThisTest) [ERROR] message");
     });
 
     it("does not fail if no key given", () => {
-      log.error("message");
+      sut.error("message");
       transport.spies.error.should.be.calledWith("(ThisTest) [ERROR] message");
     });
   });
 
   describe("log levels", () => {
     context("Level = INFO", () => {
-      const log = logFactory({
+      const sut = logFactory({
         source: "ThisTest",
         level: "INFO",
         transport
       });
 
       it("is not Trace", () => {
-        log.isTrace.should.be.false();
+        sut.isTrace.should.be.false();
       });
 
       it("is not Debug", () => {
-        log.isDebug.should.be.false();
+        sut.isDebug.should.be.false();
       });
 
       it("is Info", () => {
-        log.isInfo.should.be.true();
+        sut.isInfo.should.be.true();
       });
 
       it("is Warn", () => {
-        log.isWarn.should.be.true();
+        sut.isWarn.should.be.true();
       });
 
       it("is Error", () => {
-        log.isError.should.be.true();
+        sut.isError.should.be.true();
       });
 
       it("is Critical", () => {
-        log.isCritical.should.be.true();
+        sut.isCritical.should.be.true();
       });
     });
   });
 
   describe("events", () => {
-    const log = logFactory({
+    const sut = logFactory({
       source: "ThisTest",
       level: "INFO",
       transport
@@ -155,7 +210,7 @@ describe("Logger", () => {
       const spy = sinon.spy();
 
       events.on("ERROR", spy);
-      log.error("Hello");
+      sut.error("Hello");
 
       spy.should.be.calledWithMatch({
         level: "ERROR",

--- a/lib/LoggerOfLoggers.spec.js
+++ b/lib/LoggerOfLoggers.spec.js
@@ -1,11 +1,15 @@
 "use strict";
-const logFactory = require("./logFactory");
-const SinonTransport = require("./transports/SinonTransport");
-const should = require("should");
-const events = require("./events");
-const sinon = require("sinon");
-
 require("should-sinon");
+
+const sinon = require("sinon");
+const should = require("should");
+
+const SinonTransport = require("./transports/SinonTransport");
+
+const logFactory = require("./logFactory");
+const events = require("./events");
+
+const template = (logData) => `(${logData.source}) [${logData.level}] ${logData.message}`;
 
 describe("LoggerOfLoggers", () => {
   const transport1 = new SinonTransport();
@@ -24,10 +28,11 @@ describe("LoggerOfLoggers", () => {
 
   describe("log functions", () => {
     context("Level = INFO+DEBUG", () => {
-      const log = logFactory({
+      const sut = logFactory({
         source: "ThisTest",
         level: "INFO",
         transport: transport1,
+        template,
         variants: [
           {
             level: "DEBUG",
@@ -38,37 +43,37 @@ describe("LoggerOfLoggers", () => {
       });
 
       it("logs twice on critical", () => {
-        log.critical("message");
+        sut.critical("message");
         transport1.spies.critical.should.be.calledWith("(ThisTest) [CRITICAL] message");
         transport2.spies.critical.should.be.calledWith("CRITICAL: message ++ DEBUG");
       });
 
       it("logs twice on error", () => {
-        log.error("message");
+        sut.error("message");
         transport1.spies.error.should.be.calledWith("(ThisTest) [ERROR] message");
         transport2.spies.error.should.be.calledWith("ERROR: message ++ DEBUG");
       });
 
       it("logs twice on warn", () => {
-        log.warn("message");
+        sut.warn("message");
         transport1.spies.warn.should.be.calledWith("(ThisTest) [WARN] message");
         transport2.spies.warn.should.be.calledWith("WARN: message ++ DEBUG");
       });
 
       it("logs twice on info", () => {
-        log.info("message");
+        sut.info("message");
         transport1.spies.info.should.be.calledWith("(ThisTest) [INFO] message");
         transport2.spies.info.should.be.calledWith("INFO: message ++ DEBUG");
       });
 
       it("logs once on debug", () => {
-        log.debug("message");
+        sut.debug("message");
         transport1.spies.debug.should.not.be.called();
         transport2.spies.debug.should.be.calledWith("DEBUG: message ++ DEBUG");
       });
 
       it("doesn\'t log on trace", () => {
-        log.trace("message");
+        sut.trace("message");
         transport1.spies.trace.should.not.be.called();
         transport2.spies.trace.should.not.be.called();
       });
@@ -77,7 +82,7 @@ describe("LoggerOfLoggers", () => {
 
   describe("log levels", () => {
     context("Level = INFO+DEBUG", () => {
-      const log = logFactory({
+      const sut = logFactory({
         source: "ThisTest",
         level: "INFO",
         transport: transport1,
@@ -89,33 +94,33 @@ describe("LoggerOfLoggers", () => {
       });
 
       it("is not Trace", () => {
-        log.isTrace.should.be.false();
+        sut.isTrace.should.be.false();
       });
 
       it("is Debug", () => {
-        log.isDebug.should.be.true();
+        sut.isDebug.should.be.true();
       });
 
       it("is Info", () => {
-        log.isInfo.should.be.true();
+        sut.isInfo.should.be.true();
       });
 
       it("is Warn", () => {
-        log.isWarn.should.be.true();
+        sut.isWarn.should.be.true();
       });
 
       it("is Error", () => {
-        log.isError.should.be.true();
+        sut.isError.should.be.true();
       });
 
       it("is Critical", () => {
-        log.isCritical.should.be.true();
+        sut.isCritical.should.be.true();
       });
     });
   });
 
   describe("events", () => {
-    const log = logFactory({
+    const sut = logFactory({
       source: "ThisTest",
       level: "INFO",
       transport: transport1,
@@ -131,8 +136,8 @@ describe("LoggerOfLoggers", () => {
       const spy = sinon.spy();
 
       events.on("ERROR", spy);
-      
-      log.error("Hello");
+
+      sut.error("Hello");
 
       spy.should.be.calledOnce();
     });

--- a/lib/logFactory.js
+++ b/lib/logFactory.js
@@ -1,10 +1,13 @@
 "use strict";
 
 const _ = require("lodash");
+
 const ConsoleTransport = require("./transports").Console;
-const defaultTemplate = (logData) => `(${logData.source}) [${logData.level}] ${logData.message}`;
+
 const Logger = require("./Logger");
 const LoggerOfLoggers = require("./LoggerOfLoggers");
+
+const defaultTemplate = (logData) => `${logData.timestamp}: (${logData.source}) [${logData.level}] ${logData.message}`;
 
 const getSource = config => (
   typeof config === 'string' ? config : config.source
@@ -25,9 +28,9 @@ const logFactory = (config) => {
   const source = getSource(config);
 
   if (!_.isEmpty(config.variants)) {
-    let baseConfig = _.omit(config, ['variants']);
-    let variants = [{}].concat(config.variants);
-    let options = variants.map(v => getOptions(_.extend({}, baseConfig, v)));
+    const baseConfig = _.omit(config, ['variants']);
+    const variants = [{}].concat(config.variants);
+    const options = variants.map(v => getOptions(_.extend({}, baseConfig, v)));
 
     return new LoggerOfLoggers(source, options);
   }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "eslint": "^3.3.1",
     "eslint-config-trussle": "^2.0.0",
     "mocha": "^3.1.2",
+    "proxyquire": "^1.7.10",
     "should": "^11.1.0",
     "should-sinon": "0.0.5",
     "sinon": "^1.17.6"


### PR DESCRIPTION
When looking at log files, especially the last 100 lines when in AWS, I keep finding it would be useful to have a timestamp to understand how messages from different files correlate. 

This PR adds the already generate etc timestamp to the default template. 

We should probably double check how this will look/function with elasticsearch. 