### PR TITLE
Anonymise ILog to avoid having to port the name around.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,8 @@
-interface ILog {
+declare function logger(source: string): {
     info(message: any): void;
     debug(message: any): void;
     warn(message: any): void;
     error(message: any): void;
     trace(message: any): void;
-}
-
-declare function logger(source: string): ILog;
+};
 export = logger;


### PR DESCRIPTION
In one of my projects I'm doing the following:

```typescript
import logging = require("trussle-logging");
const log = logging("MyProject");
export default log;
```

which is giving me a compiler error:

```
error TS4023: Exported variable 'log' has or is using name 'ILog' from external module ".../trussle-logging/index" but cannot be named.
```

To avoid this, I've anonymised the `ILog` type. I'm not super comfortable with this solution, but I'm throwing it out to see whether the team has any better ideas.